### PR TITLE
GPII-2869: Key-out when the Windows session ends (logout/shutdown).

### DIFF
--- a/src/main/app.js
+++ b/src/main/app.js
@@ -525,8 +525,8 @@ gpii.app.windowMessage = function (that, hwnd, msg, wParam, lParam, result) {
     }
 };
 
-// Make gpii shutdown first, so it can close any child processes itself.
-gpii.windows.kernel32.SetProcessShutdownParameters(0x3ff, 0);
+// Make gpii shutdown last, so it doesn't close before the shutdown is cancelled by another process.
+gpii.windows.kernel32.SetProcessShutdownParameters(0x100, 0);
 
 // A wrapper that wraps gpii.app as a subcomponent. This is the grade need by configs/app.json
 // to distribute gpii.app as a subcomponent of GPII flow manager since infusion doesn't support

--- a/src/main/app.js
+++ b/src/main/app.js
@@ -516,7 +516,7 @@ fluid.onUncaughtException.addListener(function (err) {
  * @param result {object} Set a 'value' field to specify a return value.
  */
 gpii.app.windowMessage = function (that, hwnd, msg, wParam, lParam, result) {
-    // https://msdn.microsoft.com/library/aa376889
+    // https://msdn.microsoft.com/library/aa376890
     var WM_QUERYENDSESSION = 0x11;
     if (msg === WM_QUERYENDSESSION) {
         fluid.log(fluid.logLevel.FATAL, "System shutdown detected.");


### PR DESCRIPTION
Here it is, @amb26 @javihernandez.

It listens to the "I am about to shutdown" notification, tells Windows not to, then calls app.quit() (and dies), Windows then shuts down.

A few problems with this:
* It does not work via `npm start`. Not sure why, it just dies before the shutdown notification. Run electron directly (or gpii-app.exe).
* High-contrast doesn't get restored (see [new jira]).

Testing:

1. Start gpii-app.exe
2. Shutdown (or sign out of) Windows.
3. Log back in

If you want to test without fully logging out, open notepad and type something in (the unsaved document will prevent the session end), or just send the shutdown notification to GPII with this: 
[post-query-end-session-ps1](https://gist.github.com/stegru/e6e9a1b4a5ac43dee81927b3500e6fd1#file-post-query-end-session-ps1)


