### PR TITLE
GPII-3230: Made DPIScale relative to the recommended setting of the d…

### DIFF
--- a/src/main/dialog.js
+++ b/src/main/dialog.js
@@ -246,6 +246,10 @@ gpii.app.dialog.buildFileUrl = function (prefixPath, suffixPath) {
  * @return {BrowserWindow} The Electron `BrowserWindow` component
  */
 gpii.app.dialog.makeDialog = function (that, windowOptions, url, params) {
+    if (windowOptions.skipTaskbar && !windowOptions.type) {
+        windowOptions.type = "toolbar";
+    }
+
     var dialog = new BrowserWindow(windowOptions);
 
     dialog.loadURL(url);

--- a/testData/qss/settings.json
+++ b/testData/qss/settings.json
@@ -49,12 +49,12 @@
         "schema": {
             "type": "number",
             "title": "Screen Zoom",
-            "min": 1,
+            "min": -2,
             "max": 2,
-            "divisibleBy": 0.25,
-            "default": 1.25
+            "divisibleBy": 1,
+            "default": 0
         },
-        "value": 1.25,
+        "value": 0,
         "tooltip": "<div><strong>Change the screen size to make everything larger/smaller.</strong></div>",
         "widget": {
             "footerTip": ""

--- a/tests/PreferencesGroupingTests.js
+++ b/tests/PreferencesGroupingTests.js
@@ -84,14 +84,14 @@ var settingGroupsFixture = {
                     }
                 },
                 "http://registry\\.gpii\\.net/common/DPIScale":{
-                    "value":1.25,
+                    "value":1,
                     "schema":{
                         "title":"DPI Scale",
                         "description":"DPI scale factor on default monitor",
                         "type":"number",
-                        "min":1,
-                        "max":2,
-                        "divisibleBy":0.25
+                        "min":-2,
+                        "max":4,
+                        "divisibleBy":1
                     }
                 },
                 "http://registry\\.gpii\\.net/common/cursorSize":{
@@ -184,14 +184,14 @@ jqUnit.test("Group setting tests", function () {
 
     var dpiScaleKey = "http://registry\\.gpii\\.net/common/DPIScale";
     jqUnit.assertLeftHand("The default group contains the DPI scale setting", {
-        value: 1.25,
+        value: 1,
         schema: {
             title: "DPI Scale",
             description: "DPI scale factor on default monitor",
             type: "number",
-            min: 1,
-            max: 2,
-            divisibleBy: 0.25
+            min: -2,
+            max: 4,
+            divisibleBy: 1
         }
     }, defaultGroup.settingControls[dpiScaleKey]);
 


### PR DESCRIPTION
Works with https://github.com/GPII/windows/pull/190 to make the QSS set the correct values.

There's still a problem where the range of the DPI values are dynamic.