### PR TITLE
GPII-4296: Allow the custom config of the default settings url via the site config file

### DIFF
--- a/src/main/app.js
+++ b/src/main/app.js
@@ -104,9 +104,6 @@ fluid.defaults("gpii.app", {
         machineId: "@expand:{that}.installID.getMachineID()"
     },
     components: {
-        configurationHandler: {
-            type: "gpii.app.siteConfigurationHandler"
-        },
         userErrorHandler: {
             type: "gpii.app.userErrorsHandler",
             options: {
@@ -641,7 +638,7 @@ gpii.app.windowMessage = function (that, hwnd, msg, wParam, lParam, result) {
 // broadcasting directly to "components" block which probably would destroy GPII.
 
 fluid.defaults("gpii.appWrapper", {
-    gradeNames: ["fluid.component"],
+    gradeNames: ["gpii.app.siteConfigurationHandler"],
     components: {
         app: {
             type: "gpii.app"

--- a/src/main/siteConfigurationHandler.js
+++ b/src/main/siteConfigurationHandler.js
@@ -46,59 +46,60 @@ fluid.defaults("gpii.app.siteConfigurationHandler", {
                     ]
                 }
             },
-            target: "{app qssWrapper}.options.settingOptions.hiddenSettings"
+            target: "{that qssWrapper}.options.settingOptions.hiddenSettings"
         },
         distributeQssConfig: {
             record: "{that}.options.siteConfig.qss",
-            target: "{app qssWrapper}.options.siteConfig"
+            target: "{that qssWrapper}.options.siteConfig"
         },
         distributeQssWidgetConfig: {
             record: "{that}.options.siteConfig.qss",
-            target: "{app qssWidget}.options.config.params.siteConfig"
+            target: "{that qssWidget}.options.config.params.siteConfig"
         },
         distributeLanguageLabelTemplate: {
             record: "{that}.options.siteConfig.qss.languageOptionLabel",
-            target: "{app qssWrapper}.options.settingOptions.languageOptionLabelTemplate"
+            target: "{that qssWrapper}.options.settingOptions.languageOptionLabelTemplate"
         },
         distributeDefaultLanguage: {
             record: "{that}.options.siteConfig.qss.systemDefaultLanguage",
-            target: "{app qssWrapper}.options.settingOptions.systemDefaultLanguage"
+            target: "{that qssWrapper}.options.settingOptions.systemDefaultLanguage"
         },
         distributeTooltipShowDelay: {
             record: "{that}.options.siteConfig.qss.tooltipDisplayDelay",
-            target: "{app qssTooltipDialog}.options.showDelay"
+            target: "{that qssTooltipDialog}.options.showDelay"
         },
         distributeQssMorePanelConfig: {
             record: "{that}.options.siteConfig.qssMorePanel",
-            target: "{app qssMorePanel}.options.siteConfig"
+            target: "{that qssMorePanel}.options.siteConfig"
         },
         distributeQssClickOutside: {
             record: "{that}.options.siteConfig.closeQssOnClickOutside",
-            target: "{app gpiiConnector}.options.defaultPreferences.closeQssOnBlur"
+            target: "{that gpiiConnector}.options.defaultPreferences.closeQssOnBlur"
         },
         distributeOpenQssShortcut: {
             record: "{that}.options.siteConfig.openQssShortcut",
-            target: "{app gpiiConnector}.options.defaultPreferences.gpiiAppShortcut"
+            target: "{that gpiiConnector}.options.defaultPreferences.gpiiAppShortcut"
         },
         distributeDisableRestartWarning: {
             record: "{that}.options.siteConfig.disableRestartWarning",
-            target: "{app gpiiConnector}.options.defaultPreferences.disableRestartWarning"
+            target: "{that gpiiConnector}.options.defaultPreferences.disableRestartWarning"
         },
         distributeSurveyTriggersUrl: {
             record: "{that}.options.siteConfig.surveyTriggersUrl",
-            target: "{app surveyConnector}.options.config.surveyTriggersUrl"
+            target: "{that surveyConnector}.options.config.surveyTriggersUrl"
         },
         distributeAboutDialogConfig: {
             record: "{that}.options.siteConfig.aboutDialog",
-            target: "{app aboutDialog}.options.siteConfig"
+            target: "{that aboutDialog}.options.siteConfig"
         },
         distributeTrayType: {
             record: "{that}.options.siteConfig.trayType",
-            target: "{app tray}.options.trayType"
+            target: "{that tray}.options.trayType"
         },
         distributeResetToStandardProfileUrl: {
             record: "{that}.options.siteConfig.resetToStandardProfileUrl",
-            target: "{flowManager defaultSettingsLoader}.options.defaultSettingsUrl"
+            target: "{that defaultSettingsLoader}.options.defaultSettingsUrl",
+            priority: "after:flowManager.remoteDefaultSettings"
         }
     }
 });


### PR DESCRIPTION
@javihernandez, the reason that your distributeOptions on the `gpii.app.siteConfigurationHandler` cannot reach `defaultSettingsLoader` is because they are on 2 different component tree branches and `gpii.app.siteConfigurationHandler` is too deep in the `gpii.app` branch. Moving `gpii.app.siteConfigurationHandler` to the top level on this tree branch solves the problem.

Please run a careful QA for this fix since it changes the structure of the component tree. Thanks.