### PR TITLE
GPII-4065: Rename: activeContextName -> activePrefsSetName.

### DIFF
--- a/src/main/gpiiConnector.js
+++ b/src/main/gpiiConnector.js
@@ -216,7 +216,7 @@ gpii.app.gpiiConnector.handleRawChannelMessage = function (gpiiConnector, messag
  */
 gpii.app.gpiiConnector.updateActivePrefSet = function (gpiiConnector, newPrefSet) {
     gpiiConnector.send({
-        path: ["activeContextName"],
+        path: ["activePrefsSetName"],
         type: "ADD",
         value: newPrefSet
     });
@@ -278,7 +278,7 @@ gpii.app.extractPreferencesData = function (message, defaultPreferences) {
         contexts = preferences.contexts,
         gpiiKey = value.gpiiKey,
         sets = [],
-        activeSet = value.activeContextName || null,
+        activeSet = value.activePrefsSetName || null,
         settingGroups = [];
 
     if (contexts) {
@@ -831,7 +831,7 @@ gpii.app.dev.gpiiConnector.qss.distributeQssSettings = function (that, message) 
         // the type of update in the future
         that.previousState = {
             gpiiKey: value.gpiiKey,
-            activeSet: value.activeContextName
+            activeSet: value.activePrefsSetName
         };
     }
 };

--- a/tests/PreferencesGroupingTests.js
+++ b/tests/PreferencesGroupingTests.js
@@ -70,7 +70,7 @@ var settingGroupsFixture = {
         "type":"ADD",
         "value":{
             "userToken":"snapset_1a",
-            "activeContextName":"gpii-default",
+            "activePrefsSetName":"gpii-default",
             "settingControls":{
                 "http://registry\\.gpii\\.net/common/magnification":{
                     "value":2,

--- a/tests/PreferencesParsingTests.js
+++ b/tests/PreferencesParsingTests.js
@@ -35,7 +35,7 @@ var multiPrefSetsFixture = {
     "type":"ADD",
     "value":{
         "userToken":"context1",
-        "activeContextName":"gpii-default",
+        "activePrefsSetName":"gpii-default",
         "settingGroups": [
             {
                 "solutionName": "Magnifier",


### PR DESCRIPTION
This pull request should fix the CI failure in https://github.com/GPII/gpii-app/pull/179